### PR TITLE
Update README.md to merge position related commands under one category for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,6 @@ The dashboard will be available at `http://localhost:8106/` by default.
 ### Position_Commands
 - **`return_positions`**: Restores channel positions for a specified category, channel, or all channels.
   - **Usage**: `!aa return_positions [ID]`
-
-### Reset_Positions_Commands
 - **`reset_positions`**: Resets channel positions to their original settings.
   - **Usage**: `!aa reset_positions`
 


### PR DESCRIPTION
The bot shows the position related commands as separate in the readme because they're technically separate cogs, but this can be a little confusing in the README.md so I put them under the same Position_Commands category instead for the sake of clarity.